### PR TITLE
updated cmake/netcdf link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,8 @@ endif()
 
 # NetCDF
 set( NETCDF_F90 ON CACHE BOOL "Compile with Fortran NetCDF" )
-find_package( NetCDF REQUIRED )
-include_directories( ${NETCDF_INCLUDE_DIR} )
+find_package( NetCDF REQUIRED COMPONENTS Fortran )
+include_directories( ${NETCDF_INCLUDE_DIRS} )
 
 # fms
 


### PR DESCRIPTION
netcdf package name update to compile on hera

- Other Relevant Details: merge to feature/ecbuild, which is going to run with soca-cice6
